### PR TITLE
Allow running in check_mode

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -50,6 +50,7 @@
     url:  'https://install.pi-hole.net'
     dest: '/tmp/pihole-install.sh'
     mode: 'u+rwx'
+  ignore_errors: '{{ ansible_check_mode }}'
   when: not pihole_installed
 
 - name: 'install | install'


### PR DESCRIPTION
If running this in check mode `ansible.builtin.get_url` sends a `HEAD` request to `https://install.pi-hole.net` which responds to that with `HTTP Error 405: Method Not Allowed`   So we allow it to error in check mode in case they'll ever allow a `HEAD` request