### PR TITLE
Force password variable into string

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -66,9 +66,9 @@
 # * https://discourse.pi-hole.net/t/what-is-setupvars-conf-and-how-do-i-use-it/3533/5
 - name: 'install | set random password (no install password set)'
   ansible.builtin.command: "pihole -a -p {{ lookup('password', '/dev/null chars=ascii_lowercase,digits length=8') }}"
-  when: pihole_webpassword|length == 0
+  when: pihole_webpassword|string|length == 0
 
 - name: 'install | set password'
   ansible.builtin.command: 'pihole -a -p {{ pihole_webpassword }}'
-  when: pihole_webpassword|length > 0
+  when: pihole_webpassword|string|length > 0
   no_log: true # password


### PR DESCRIPTION
If a variable is declared as a vault string, then it's a `AnsibleVaultEncryptedUnicode`, which needs to be converted to a string first before we can measure the length.
```
The conditional check 'pihole_webpassword|length == 0' failed. The error was: Unexpected templating type error occurred on ({% if pihole_webpassword|length == 0 %} True {% else %} False {% endif %}): object of type 'AnsibleVaultEncryptedUnicode' has no len()
```