### PR TITLE
Reconfigure pihole if the config changed

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,4 +6,4 @@
 # pihole restartdns restarts all required pihole services.
 # Reference: https://discourse.pi-hole.net/t/the-pihole-command-with-examples/738
 - name: 'restart pihole dns'
-  ansible.builtin.command: 'pihole restartdns'
+  ansible.builtin.command: '/etc/.pihole/automated\ install/basic-install.sh --reconfigure --unattended'


### PR DESCRIPTION
Just restarting does not reconfigure.

Sadly there's no better command to trigger the reconfigure in unattended mode