### PR TITLE
Create 'pihole' user before attempting to set file ownership to 'pihole'

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,7 @@ galaxy_info:
       versions:
         - 'buster'
         - 'bullseye'
+        - 'bookworm'
     - name: 'EL'
       versions:
         - 'all'

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -59,6 +59,18 @@
     mode:  0644
   notify: 'restart pihole dns'
 
+- name: 'install | create pihole group'
+  ansible.builtin.group:
+    name: pihole
+
+- name: 'install | create pihole user'
+  ansible.builtin.user:
+    name: pihole
+    create_home: false
+    group: pihole
+    shell: /usr/sbin/nologin
+    system: true
+
 - name: 'install | set FTL config'
   ansible.builtin.template:
     src: 'pihole-FTL.conf.j2'


### PR DESCRIPTION
Tested against Debian 10 (buster), 11 (bullseye), and 12 (bookworm).
Closes #14 